### PR TITLE
Added route to delete docs

### DIFF
--- a/BackEnd/specs/swagger.yaml
+++ b/BackEnd/specs/swagger.yaml
@@ -58,7 +58,7 @@ paths:
     /deleteProject:
         delete:
           operationId: deleteProject
-          description: Delete a given version of a project to the database
+          description: Delete a given language for a version of a project to the database, have differents behavior if some parameters are empty (i.e. "") (look at parameters description for more)
           security:
             - basicAuth: []
           parameters:
@@ -66,17 +66,17 @@ paths:
               type: string
               required: true
               in: formData
-              description: Display name of the project
+              description: Display name of the project, cannot be empty
             - name: language
               type: string
               required: true
               in: formData
-              description: Programming language used in this version of the project
+              description: Programming language used in this version of the project, if empty delete all languages for this version
             - name: version
               type: string
               required: true
               in: formData
-              description: a version number that match SemVer specification
+              description: a version number that match SemVer specification, if empty delete the whole project (cannot be empty if language is not empty)
           responses:
             200:
               description: project was deleted successfully

--- a/BackEnd/specs/swagger.yaml
+++ b/BackEnd/specs/swagger.yaml
@@ -55,6 +55,36 @@ paths:
         401:
           description: provided password is wrong
 
+    /deleteProject:
+        delete:
+          operationId: deleteProject
+          description: Delete a given version of a project to the database
+          security:
+            - basicAuth: []
+          parameters:
+            - name: name
+              type: string
+              required: true
+              in: formData
+              description: Display name of the project
+            - name: language
+              type: string
+              required: true
+              in: formData
+              description: Programming language used in this version of the project
+            - name: version
+              type: string
+              required: true
+              in: formData
+              description: a version number that match SemVer specification
+          responses:
+            200:
+              description: project was deleted successfully
+            400:
+              description: one or more parameters are invalid
+            401:
+              description: provided password is wrong
+
 securityDefinitions:
   basicAuth:
     type: basic
@@ -92,4 +122,3 @@ definitions:
       index:
         type: string
         description: an host-relative path to the index.html file of the documentation for a given version in a given project
-

--- a/BackEnd/src/controllers/DeleteProject.php
+++ b/BackEnd/src/controllers/DeleteProject.php
@@ -168,19 +168,19 @@ class DeleteProject extends BaseController
 
         $archiveFolder =  $this->container->get('archiveRoot');
 
+        $archiveFileName = preg_replace("/^$/", "*", $fileName);
+
         $archiveDestination = [
             $archiveFolder,
-            implode('-', $fileName).'.zip'
+            implode('-', $archiveFileName).'.zip'
         ];
 
         $archiveDestinationPath = implode(DIRECTORY_SEPARATOR, $archiveDestination);
 
-        if (file_exists($archiveDestinationPath) === true) {
-            try {
-                unlink($archiveDestinationPath);
-            } catch (\Exception $e) {
-                $this->errorMessage = 'unlinking backup failed.';
-                return false;
+        $archiveToDelete = glob($archiveDestinationPath);
+        if (count($archiveToDelete) !== 0) {
+            foreach($archiveToDelete as $f) {
+                unlink($f);
             }
         } else {
             error_log('No backup found ' . $archiveDestinationPath);

--- a/BackEnd/src/controllers/DeleteProject.php
+++ b/BackEnd/src/controllers/DeleteProject.php
@@ -1,0 +1,279 @@
+<?php
+
+namespace HostMyDocs\Controllers;
+
+use Chumper\Zipper\Zipper;
+use Slim\Container;
+use Slim\Http\Response as Response;
+use Slim\Http\Request as Request;
+use Slim\Http\UploadedFile;
+use Symfony\Component\Filesystem\Filesystem;
+
+class DeleteProject extends BaseController
+{
+    /**
+     * @var null|string Name of the project to add
+     */
+    private $name = null;
+
+    /**
+     * @var null|string SemVer representation of the version of the project to add
+     */
+    private $version = null;
+
+    /**
+     * @var null|string Programming language of the project to add
+     */
+    private $language = null;
+
+    /**
+     * @var null|Filesystem Symfony Filesystem wrapper
+     */
+    private $filesystem = null;
+
+    public function __construct(Container $container)
+    {
+        parent::__construct($container);
+        $this->filesystem = new Filesystem();
+    }
+
+    /**
+     * Main method of the controller
+     *
+     * @param Request $request
+     * @param Response $response
+     * @return Response
+     */
+    public function __invoke(Request $request, Response $response)
+    {
+        // increasing execution time
+        ini_set('max_execution_time', 3600);
+
+        $requestParams = $request->getParsedBody();
+        var_dump($requestParams);
+
+        if (count($requestParams) === 0) {
+            $this->errorMessage = 'no parameters found';
+            $response = $response->write($this->errorMessage);
+            return $response->withStatus(400);
+        }
+
+        error_log('Processing a new request');
+
+        if (array_key_exists('name', $requestParams)) {
+            $this->name = $requestParams['name'];
+        }
+
+        if (array_key_exists('version', $requestParams)) {
+            $this->version = $requestParams['version'];
+        }
+
+        if (array_key_exists('language', $requestParams)) {
+            $this->language = $requestParams['language'];
+        }
+
+        error_log('Checking provided parameters');
+
+        if ($this->checkParams() === false) {
+            if ($this->errorMessage !== null) {
+                $response = $response->write($this->errorMessage);
+            }
+            return $response->withStatus(400);
+        }
+
+        error_log('Parameters OK');
+
+        error_log("Name of the project : $this->name");
+        error_log("Version of the project : $this->version");
+        error_log("Language of the project : $this->language");
+
+        error_log('Deleting folder + backup');
+
+        if ($this->delete() === false) {
+            if ($this->errorMessage !== null) {
+                $response = $response->write($this->errorMessage);
+            }
+            return $response->withStatus(400);
+        }
+
+        error_log('Delteting done.');
+
+        error_log('Project deleted successfully');
+
+        return $response->withStatus(200);
+    }
+
+    /**
+     * Verifying that all parameters are valid
+     *
+     * @return bool the error code the client will receive or true in case of success
+     */
+    private function checkParams() : bool
+    {
+        if ($this->name === null) {
+            $this->errorMessage = 'name is empty';
+            return false;
+        }
+
+        if (strpos($this->name, '/') !== false) {
+            $this->errorMessage = 'name cannot contains slashes';
+            return false;
+        }
+
+        if (strlen($this->name) === 0) {
+            $this->errorMessage = 'name cannot be empty';
+            return false;
+        }
+
+        if ($this->version === null) {
+            $this->errorMessage = 'version is empty';
+            return false;
+        }
+
+        if (strpos($this->version, '/') !== false) {
+            $this->errorMessage = 'version cannot contains slashes';
+            return false;
+        }
+
+        if ($this->language === null) {
+            $this->errorMessage = 'language is empty';
+            return false;
+        }
+
+        if (strpos($this->language, '/') !== false) {
+            $this->errorMessage = 'language cannot contains slashes';
+            return false;
+        }
+
+        if (strlen($this->language) !== 0 && strlen($this->version) === 0) {
+            $this->errorMessage = 'language must be empty when version is empty';
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Delete doc for project and corresponding backup
+     *
+     * @return bool
+     */
+    private function delete() : bool
+    {
+        $fileName = [
+            $this->name,
+            $this->version,
+            $this->language
+        ];
+
+        $archiveFolder =  $this->container->get('archiveRoot');
+
+        $archiveDestination = [
+            $archiveFolder,
+            implode('-', $fileName).'.zip'
+        ];
+
+        $archiveDestinationPath = implode(DIRECTORY_SEPARATOR, $archiveDestination);
+
+        if (file_exists($archiveDestinationPath) === true) {
+            try {
+                unlink($archiveDestinationPath);
+            } catch (\Exception $e) {
+                $this->errorMessage = 'unlinking backup failed.';
+                return false;
+            }
+        } else {
+            error_log('No backup found ' . $archiveDestinationPath);
+        }
+
+        $storageFolder =  $this->container->get('storageRoot');
+
+        $storageDestination = [
+            $storageFolder,
+            implode(DIRECTORY_SEPARATOR, $fileName)
+        ];
+
+        $storageDestinationPath = implode(DIRECTORY_SEPARATOR, $storageDestination);
+
+        if (file_exists($storageDestinationPath) === true) {
+            try {
+                if($this->deleteDirectory($storageDestinationPath) === false) {
+                    $this->errorMessage = 'deleting project failed.';
+                    return false;
+                }
+                if($this->deleteEmptyDirectories($storageFolder) === false) {
+                    $this->errorMessage = 'deleting empty folders failed. /listProject will fail until you delete them';
+                    return false;
+                }
+            } catch (\Exception $e) {
+                $this->errorMessage = 'deleting project failed.';
+                return false;
+            }
+        } else {
+            $this->errorMessage = 'project does not exists.';
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * delete the directory in argument $dir
+     *
+     * @param  [string] $dir path to dir to delete
+     *
+     * @return bool
+     */
+    private function deleteDirectory($dir) : bool {
+        if (!file_exists($dir)) {
+            return true;
+        }
+
+        if (!is_dir($dir)) {
+            return unlink($dir);
+        }
+
+        $dirContent = array_diff(scandir($dir), array('..', '.'));
+        foreach ($dirContent as $item) {
+
+            if (!$this->deleteDirectory($dir . DIRECTORY_SEPARATOR . $item)) {
+                return false;
+            }
+
+        }
+
+        return rmdir($dir);
+    }
+
+    /**
+     * delete the directory in argument $dir
+     *
+     * @param  [string] $dir path to dir to delete
+     *
+     * @return bool
+     */
+    private function deleteEmptyDirectories($dir) : bool {
+        if (!file_exists($dir)) {
+            return true;
+        }
+
+        if (!is_dir($dir)) {
+            return true;
+        }
+
+        $dirContentBefore = array_diff(scandir($dir), array('..', '.'));
+        foreach ($dirContentBefore as $item) {
+
+            if (!$this->deleteEmptyDirectories($dir . DIRECTORY_SEPARATOR . $item)) {
+                return false;
+            }
+
+        }
+        $dirContentAfter = array_diff(scandir($dir), array('..', '.'));
+        if (count($dirContentAfter) === 0) {
+            return rmdir($dir);
+        }
+
+        return true;
+    }
+}

--- a/BackEnd/src/controllers/DeleteProject.php
+++ b/BackEnd/src/controllers/DeleteProject.php
@@ -2,11 +2,9 @@
 
 namespace HostMyDocs\Controllers;
 
-use Chumper\Zipper\Zipper;
 use Slim\Container;
 use Slim\Http\Response as Response;
 use Slim\Http\Request as Request;
-use Slim\Http\UploadedFile;
 use Symfony\Component\Filesystem\Filesystem;
 
 class DeleteProject extends BaseController
@@ -46,11 +44,7 @@ class DeleteProject extends BaseController
      */
     public function __invoke(Request $request, Response $response)
     {
-        // increasing execution time
-        ini_set('max_execution_time', 3600);
-
         $requestParams = $request->getParsedBody();
-        var_dump($requestParams);
 
         if (count($requestParams) === 0) {
             $this->errorMessage = 'no parameters found';

--- a/BackEnd/src/middleware.php
+++ b/BackEnd/src/middleware.php
@@ -10,4 +10,11 @@ $slim->add(new HttpBasicAuthentication([
     'users' => $slim->getContainer()->get('authorizedUser')
 ]));
 
+$slim->add(new HttpBasicAuthentication([
+    'relaxed' => [],
+    'path' => '/deleteProject',
+    'secure' => $slim->getContainer()->get('shouldSecure'),
+    'users' => $slim->getContainer()->get('authorizedUser')
+]));
+
 $slim->add(new Cache('public', 86400));

--- a/BackEnd/src/middleware.php
+++ b/BackEnd/src/middleware.php
@@ -5,14 +5,7 @@ use Slim\Middleware\HttpBasicAuthentication;
 
 $slim->add(new HttpBasicAuthentication([
     'relaxed' => [],
-    'path' => '/addProject',
-    'secure' => $slim->getContainer()->get('shouldSecure'),
-    'users' => $slim->getContainer()->get('authorizedUser')
-]));
-
-$slim->add(new HttpBasicAuthentication([
-    'relaxed' => [],
-    'path' => '/deleteProject',
+    'path' => ['/addProject', '/deleteProject'],
     'secure' => $slim->getContainer()->get('shouldSecure'),
     'users' => $slim->getContainer()->get('authorizedUser')
 ]));

--- a/BackEnd/src/routes.php
+++ b/BackEnd/src/routes.php
@@ -1,6 +1,7 @@
 <?php
 
 use HostMyDocs\Controllers\AddProject;
+use HostMyDocs\Controllers\DeleteProject;
 use HostMyDocs\Controllers\ListProjects;
 use Slim\Http\Response as Response;
 use Slim\Http\Request as Request;
@@ -9,6 +10,6 @@ $slim->get('/', function (Request $request, Response $response) {
     return $response->write('What did you expect ?');
 });
 
-
 $slim->get('/listProjects', ListProjects::class);
 $slim->post('/addProject', AddProject::class);
+$slim->delete('/deleteProject', DeleteProject::class);

--- a/BackEnd/tests/DeleteProjectTest.php
+++ b/BackEnd/tests/DeleteProjectTest.php
@@ -66,10 +66,56 @@ class DeleteProjectTest extends BaseTestCase
                 ],
                 'statusCode' => 401
             ],
+            'name null' => [
+                [],
+                [
+                    'version' => '6.6.6',
+                    'language' => 'language'
+                ],
+                [
+                    'serverCredentials' => $this->serverCredentials,
+                    'userCredentials' => $this->serverCredentials
+                ],
+                'statusCode' => 400
+            ],
+            'empty name' => [
+                [],
+                [
+                    'name' => ''
+                ],
+                [
+                    'serverCredentials' => $this->serverCredentials,
+                    'userCredentials' => $this->serverCredentials
+                ],
+                'statusCode' => 400
+            ],
+            'name with slash' => [
+                [],
+                [
+                    'name' => 'Some/Project'
+                ],
+                [
+                    'serverCredentials' => $this->serverCredentials,
+                    'userCredentials' => $this->serverCredentials
+                ],
+                'statusCode' => 400
+            ],
             'name' => [
                 [],
                 [
                     'name' => 'SomeProject'
+                ],
+                [
+                    'serverCredentials' => $this->serverCredentials,
+                    'userCredentials' => $this->serverCredentials
+                ],
+                'statusCode' => 400
+            ],
+            'name + version with slash' => [
+                [],
+                [
+                    'name' => 'AnotherProject',
+                    'version' => '6/6.6',
                 ],
                 [
                     'serverCredentials' => $this->serverCredentials,
@@ -107,6 +153,19 @@ class DeleteProjectTest extends BaseTestCase
                     'name' => 'AnotherProject',
                     'language' => 'R\'lyehian',
                     'version' => ''
+                ],
+                [
+                    'serverCredentials' => $this->serverCredentials,
+                    'userCredentials' => $this->serverCredentials
+                ],
+                'statusCode' => 400
+            ],
+            'name + version + language with slash' => [
+                [],
+                [
+                    'name' => 'AnotherProject',
+                    'version' => '6.6.6',
+                    'language' => 'with/slash',
                 ],
                 [
                     'serverCredentials' => $this->serverCredentials,

--- a/BackEnd/tests/DeleteProjectTest.php
+++ b/BackEnd/tests/DeleteProjectTest.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace HostMyDocs\Tests;
+
+class DeleteProjectTest extends BaseTestCase
+{
+    /**
+     * @var array credentials to be inserted into environment
+     */
+    private $serverCredentials = 'beep:bep';
+
+    private $wrongCredentials = 'plop:plop';
+
+    private static $isInitialized = false;
+
+    public function setUp()
+    {
+        // allow setUp to be done once
+        if (self::$isInitialized) {
+            return;
+        }
+        self::$isInitialized = true;
+
+        // create project for delete using every params
+        $parameters = [
+            'name' => 'AnotherProject',
+            'language' => 'R\'lyehian',
+            'version' => '6.6.6'
+        ];
+        $files = ['archive' => $this->createZipFile()];
+        $credentials = $this->serverCredentials;
+
+        $this->runApp('POST', '/addProject', $parameters, $files, $credentials);
+
+        // create project for multiple delete
+        $parameters = [
+            'name' => 'AThirdProject',
+            'language' => 'ALanguage',
+            'version' => '6.6.6'
+        ];
+        $files = ['archive' => $this->createZipFile()];
+        $credentials = $this->serverCredentials;
+        $this->runApp('POST', '/addProject', $parameters, $files, $credentials);
+
+        $parameters = [
+            'name' => 'AThirdProject',
+            'language' => 'ASecondLanguage',
+            'version' => '6.6.6'
+        ];
+        $files = ['archive' => $this->createZipFile()];
+        $credentials = $this->serverCredentials;
+        $this->runApp('POST', '/addProject', $parameters, $files, $credentials);
+
+        $parameters = [
+            'name' => 'AThirdProject',
+            'language' => 'ALanguage',
+            'version' => '4.2'
+        ];
+        $files = ['archive' => $this->createZipFile()];
+        $credentials = $this->serverCredentials;
+        $this->runApp('POST', '/addProject', $parameters, $files, $credentials);
+
+        $parameters = [
+            'name' => 'AThirdProject',
+            'language' => 'ALanguage',
+            'version' => '0'
+        ];
+        $files = ['archive' => $this->createZipFile()];
+        $credentials = $this->serverCredentials;
+        $this->runApp('POST', '/addProject', $parameters, $files, $credentials);
+    }
+
+    /**
+     * @dataProvider arrayOfParametersProvider
+     */
+    public function testDeleteProject($parameters, $credentialsArray, $statusCode)
+    {
+        $credentials = null;
+
+        if (array_key_exists('serverCredentials', $credentialsArray)) {
+            putenv('CREDENTIALS='.$credentialsArray['serverCredentials']);
+        }
+
+        if (array_key_exists('userCredentials', $credentialsArray)) {
+            $credentials = $credentialsArray['userCredentials'];
+        }
+
+        $response = $this->runApp('DELETE', '/deleteProject', $parameters, null, $credentials);
+        $this->assertEquals($statusCode, $response->getStatusCode());
+    }
+
+    /**
+     * Providing parameters for requests
+     */
+    public function arrayOfParametersProvider()
+    {
+        return [
+            'no credentials' => [
+                [],
+                [],
+                'statusCode' => 401
+            ],
+            'good credentials but no params' => [
+                [],
+                [
+                    'serverCredentials' => $this->serverCredentials,
+                    'userCredentials' => $this->serverCredentials
+                ],
+                'statusCode' => 400
+            ],
+            'bad credentials' => [
+                [],
+                [
+                    'serverCredentials' => $this->serverCredentials,
+                    'userCredentials' => $this->wrongCredentials
+                ],
+                'statusCode' => 401
+            ],
+            'name' => [
+                [
+                    'name' => 'SomeProject'
+                ],
+                [
+                    'serverCredentials' => $this->serverCredentials,
+                    'userCredentials' => $this->serverCredentials
+                ],
+                'statusCode' => 400
+            ],
+            'name + version' => [
+                [
+                    'name' => 'AnotherProject',
+                    'version' => '6.6.6',
+                ],
+                [
+                    'serverCredentials' => $this->serverCredentials,
+                    'userCredentials' => $this->serverCredentials
+                ],
+                'statusCode' => 400
+            ],
+            'name + language' => [
+                [
+                    'name' => 'AnotherProject',
+                    'language' => 'R\'lyehian',
+                ],
+                [
+                    'serverCredentials' => $this->serverCredentials,
+                    'userCredentials' => $this->serverCredentials
+                ],
+                'statusCode' => 400
+            ],
+            'name + language + empty version' => [
+                [
+                    'name' => 'AnotherProject',
+                    'language' => 'R\'lyehian',
+                    'version' => ''
+                ],
+                [
+                    'serverCredentials' => $this->serverCredentials,
+                    'userCredentials' => $this->serverCredentials
+                ],
+                'statusCode' => 400
+            ],
+            'valid parameters project not existing' => [
+                [
+                    'name' => 'AnotherProject',
+                    'language' => 'R\'lyehian',
+                    'version' => 'v2017'
+                ],
+                [
+                    'serverCredentials' => $this->serverCredentials,
+                    'userCredentials' => $this->serverCredentials
+                ],
+                'statusCode' => 400
+            ],
+            'valid parameters' => [
+                [
+                    'name' => 'AnotherProject',
+                    'language' => 'R\'lyehian',
+                    'version' => '6.6.6'
+                ],
+                [
+                    'serverCredentials' => $this->serverCredentials,
+                    'userCredentials' => $this->serverCredentials
+                ],
+                'statusCode' => 200
+            ],
+            'valid empty language parameters' => [
+                [
+                    'name' => 'AThirdProject',
+                    'language' => '',
+                    'version' => '6.6.6'
+                ],
+                [
+                    'serverCredentials' => $this->serverCredentials,
+                    'userCredentials' => $this->serverCredentials
+                ],
+                'statusCode' => 200
+            ],
+            'valid empty language + empty version parameters' => [
+                [
+                    'name' => 'AThirdProject',
+                    'language' => '',
+                    'version' => ''
+                ],
+                [
+                    'serverCredentials' => $this->serverCredentials,
+                    'userCredentials' => $this->serverCredentials
+                ],
+                'statusCode' => 200
+            ]
+        ];
+    }
+}

--- a/BackEnd/tests/DeleteProjectTest.php
+++ b/BackEnd/tests/DeleteProjectTest.php
@@ -11,70 +11,17 @@ class DeleteProjectTest extends BaseTestCase
 
     private $wrongCredentials = 'plop:plop';
 
-    private static $isInitialized = false;
-
-    public function setUp()
-    {
-        // allow setUp to be done once
-        if (self::$isInitialized) {
-            return;
-        }
-        self::$isInitialized = true;
-
-        // create project for delete using every params
-        $parameters = [
-            'name' => 'AnotherProject',
-            'language' => 'R\'lyehian',
-            'version' => '6.6.6'
-        ];
-        $files = ['archive' => $this->createZipFile()];
-        $credentials = $this->serverCredentials;
-
-        $this->runApp('POST', '/addProject', $parameters, $files, $credentials);
-
-        // create project for multiple delete
-        $parameters = [
-            'name' => 'AThirdProject',
-            'language' => 'ALanguage',
-            'version' => '6.6.6'
-        ];
-        $files = ['archive' => $this->createZipFile()];
-        $credentials = $this->serverCredentials;
-        $this->runApp('POST', '/addProject', $parameters, $files, $credentials);
-
-        $parameters = [
-            'name' => 'AThirdProject',
-            'language' => 'ASecondLanguage',
-            'version' => '6.6.6'
-        ];
-        $files = ['archive' => $this->createZipFile()];
-        $credentials = $this->serverCredentials;
-        $this->runApp('POST', '/addProject', $parameters, $files, $credentials);
-
-        $parameters = [
-            'name' => 'AThirdProject',
-            'language' => 'ALanguage',
-            'version' => '4.2'
-        ];
-        $files = ['archive' => $this->createZipFile()];
-        $credentials = $this->serverCredentials;
-        $this->runApp('POST', '/addProject', $parameters, $files, $credentials);
-
-        $parameters = [
-            'name' => 'AThirdProject',
-            'language' => 'ALanguage',
-            'version' => '0'
-        ];
-        $files = ['archive' => $this->createZipFile()];
-        $credentials = $this->serverCredentials;
-        $this->runApp('POST', '/addProject', $parameters, $files, $credentials);
-    }
-
     /**
      * @dataProvider arrayOfParametersProvider
      */
-    public function testDeleteProject($parameters, $credentialsArray, $statusCode)
+    public function testDeleteProject($projectsToPost, $parameters, $credentialsArray, $statusCode)
     {
+        foreach ($projectsToPost as $project) {
+            $files = ['archive' => $this->createZipFile()];
+            $credentials= $this->serverCredentials;
+            $this->runApp('POST', '/addProject', $parameters, $files, $credentials);
+        }
+
         $credentials = null;
 
         if (array_key_exists('serverCredentials', $credentialsArray)) {
@@ -98,9 +45,11 @@ class DeleteProjectTest extends BaseTestCase
             'no credentials' => [
                 [],
                 [],
+                [],
                 'statusCode' => 401
             ],
             'good credentials but no params' => [
+                [],
                 [],
                 [
                     'serverCredentials' => $this->serverCredentials,
@@ -110,6 +59,7 @@ class DeleteProjectTest extends BaseTestCase
             ],
             'bad credentials' => [
                 [],
+                [],
                 [
                     'serverCredentials' => $this->serverCredentials,
                     'userCredentials' => $this->wrongCredentials
@@ -117,6 +67,7 @@ class DeleteProjectTest extends BaseTestCase
                 'statusCode' => 401
             ],
             'name' => [
+                [],
                 [
                     'name' => 'SomeProject'
                 ],
@@ -127,6 +78,7 @@ class DeleteProjectTest extends BaseTestCase
                 'statusCode' => 400
             ],
             'name + version' => [
+                [],
                 [
                     'name' => 'AnotherProject',
                     'version' => '6.6.6',
@@ -138,6 +90,7 @@ class DeleteProjectTest extends BaseTestCase
                 'statusCode' => 400
             ],
             'name + language' => [
+                [],
                 [
                     'name' => 'AnotherProject',
                     'language' => 'R\'lyehian',
@@ -149,6 +102,7 @@ class DeleteProjectTest extends BaseTestCase
                 'statusCode' => 400
             ],
             'name + language + empty version' => [
+                [],
                 [
                     'name' => 'AnotherProject',
                     'language' => 'R\'lyehian',
@@ -161,6 +115,7 @@ class DeleteProjectTest extends BaseTestCase
                 'statusCode' => 400
             ],
             'valid parameters project not existing' => [
+                [],
                 [
                     'name' => 'AnotherProject',
                     'language' => 'R\'lyehian',
@@ -174,6 +129,13 @@ class DeleteProjectTest extends BaseTestCase
             ],
             'valid parameters' => [
                 [
+                    [
+                        'name' => 'AnotherProject',
+                        'language' => 'R\'lyehian',
+                        'version' => '6.6.6'
+                    ]
+                ],
+                [
                     'name' => 'AnotherProject',
                     'language' => 'R\'lyehian',
                     'version' => '6.6.6'
@@ -186,6 +148,18 @@ class DeleteProjectTest extends BaseTestCase
             ],
             'valid empty language parameters' => [
                 [
+                    [
+                        'name' => 'AThirdProject',
+                        'language' => 'R\'lyehian',
+                        'version' => '6.6.6'
+                    ],
+                    [
+                        'name' => 'AThirdProject',
+                        'language' => 'ThePerfectLanguage',
+                        'version' => '6.6.6'
+                    ]
+                ],
+                [
                     'name' => 'AThirdProject',
                     'language' => '',
                     'version' => '6.6.6'
@@ -197,6 +171,23 @@ class DeleteProjectTest extends BaseTestCase
                 'statusCode' => 200
             ],
             'valid empty language + empty version parameters' => [
+                [
+                    [
+                        'name' => 'AThirdProject',
+                        'language' => 'R\'lyehian',
+                        'version' => '6.6.6'
+                    ],
+                    [
+                        'name' => 'AThirdProject',
+                        'language' => 'ThePerfectLanguage',
+                        'version' => '6.6.6'
+                    ],
+                    [
+                        'name' => 'AThirdProject',
+                        'language' => 'ThePerfectLanguage',
+                        'version' => '4.2'
+                    ]
+                ],
                 [
                     'name' => 'AThirdProject',
                     'language' => '',

--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ curl --request POST \
 curl --request DELETE \
     --url http://localhost:8080/BackEnd/deleteProject \
     --user user:password \
-    --header 'content-type: application/x-www-form-urlencoded;authorization: Basic dXNlcjpwYXNzd29yZA==' \
-    --header 'boundary=---011000010111000001101001' \
     -d "name=DocumentationName" \
     -d "version=1.0.0" \
     -d "language=YourProgrammingLanguage"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Note that by default the BackEnd will require to be secured with HTTPS. If you w
 You can refer to the [production setup section](#production-setup) to properly deploy an HostMyDocs instance with SSL enabled.
 
 ## Getting Started
+### Add a doc
 
 1) Launch the application and its server with ```docker run -e CREDENTIALS=user:password -e SHOULD_SECURE=FALSE -v `pwd`:/data -p 8080:80 tracesoftware/hostmydocs```
 
@@ -47,6 +48,38 @@ curl --request POST \
 ```
 
 5) Open [http://localhost:8080](http://localhost:8080) to see your uploaded docs !
+
+### Delete a doc
+
+1) Launch the application and its server with ```docker run -e CREDENTIALS=user:password -e SHOULD_SECURE=FALSE -v `pwd`:/data -p 8080:80 tracesoftware/hostmydocs```
+
+2) delete using cURL by example :
+```bash
+curl --request DELETE \
+    --url http://localhost:8080/BackEnd/deleteProject \
+    --user user:password \
+    --header 'content-type: application/x-www-form-urlencoded;authorization: Basic dXNlcjpwYXNzd29yZA==' \
+    --header 'boundary=---011000010111000001101001' \
+    -d "name=DocumentationName" \
+    -d "version=1.0.0" \
+    -d "language=YourProgrammingLanguage"
+```
+
+> Note that you can write
+> ```
+> -d "language="
+> ```
+> to delete a whole `version` for the project
+>
+> OR
+>
+> ```bash
+> -d "version=1.0.0" \
+> -d "language=YourProgrammingLanguage"
+> ```
+> to delete the whole `project`
+
+3) Open [http://localhost:8080](http://localhost:8080) to see your remainings docs !
 
 ## BackEnd API
 


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR add a delete route to the application used to delete a project or part of it
The used route is `/BackEnd/deleteProject`
It take three parameters : 
- the `name` of the doc to delete
- the `version` of the doc to delete
- the `language` of the doc to delete

and use the same authentification as the `/addProject` route

Things done :
* [x] delete route
    * [x] delete
        * [x] the archive
        * [x] the files
            * [x] the resulting empty folder
    * [x] delete part of the project
        * [x] delete doc for a given `name -> version -> language` combination
        * [x] delete all languages for a given `name -> version` combination
        * [x] delete all version for a give `name`
* [x] create tests
* [x] update README

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

**motivation**

Before this change the only way to delete a doc was to use a file system to delete the doc folder manually.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

I used the command found in `.travis.yml` 
```bash
docker run -v "`pwd`:/home/builder/" tracesoftware/gitlab-builder:php7-cli /bin/sh -c "mkdir -p $ARCHIVE_PATH $DOCS_PATH; chmod -R 777 $DATA_PATH; composer update; composer test"
```
And got the following output : 

![capture d ecran de 2018-05-23 14-31-53](https://user-images.githubusercontent.com/17279801/40424694-918dd37e-5e96-11e8-99a0-68f9334e7488.png)

showing everything is good.

I did not run the tests for FrontEnd since I didn't touch it.

<!-- Make sure tests pass on Travis. -->


**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
closes #42 
